### PR TITLE
DRY out some of the generated code

### DIFF
--- a/lib/Jemplate.pm
+++ b/lib/Jemplate.pm
@@ -408,13 +408,10 @@ if (typeof(Jemplate) == 'undefined')
 Jemplate.applier = function(block) {
     return function(context) {
         if (!context) throw('Jemplate function called without context\\n');
-        var stash = context.stash, output = '';
         try {
-            output = block(stash, output);
+            return block(context.stash, context);
         } catch(e) {
-            throw(context.set_error(e, output));
-        } finally {
-            return output;
+            throw(e);
         }
     }
 };

--- a/lib/Jemplate.pm
+++ b/lib/Jemplate.pm
@@ -405,6 +405,20 @@ if (typeof(exports) == 'object') {
 if (typeof(Jemplate) == 'undefined')
     throw('Jemplate.js must be loaded before any Jemplate template files');
 
+Jemplate.applier = function(block) {
+    return function(context) {
+        if (!context) throw('Jemplate function called without context\\n');
+        var stash = context.stash, output = '';
+        try {
+            output = block(stash, output);
+        } catch(e) {
+            throw(context.set_error(e, output));
+        } finally {
+            return output;
+        }
+    }
+};
+
 ...
 }
 

--- a/lib/Jemplate.pm
+++ b/lib/Jemplate.pm
@@ -405,11 +405,11 @@ if (typeof(exports) == 'object') {
 if (typeof(Jemplate) == 'undefined')
     throw('Jemplate.js must be loaded before any Jemplate template files');
 
-Jemplate.applier = function(block) {
+Jemplate.applier = function(func) {
     return function(context) {
         if (!context) throw('Jemplate function called without context\\n');
         try {
-            return block(context.stash, context);
+            return func(context.stash, context);
         } catch(e) {
             throw(e);
         }

--- a/lib/Jemplate/Directive.pm
+++ b/lib/Jemplate/Directive.pm
@@ -19,7 +19,7 @@ sub template {
     my ($class, $block) = @_;
 
     return "function() { return ''; }" unless $block =~ /\S/;
-    return "Jemplate.applier(function(stash, output) { $block return output; });\n";
+    return "Jemplate.applier(function(stash, output) {\n $block return output; });\n\n";
     
 }
  

--- a/lib/Jemplate/Directive.pm
+++ b/lib/Jemplate/Directive.pm
@@ -19,7 +19,7 @@ sub template {
     my ($class, $block) = @_;
 
     return "function() { return ''; }" unless $block =~ /\S/;
-    return "Jemplate.applier(function(stash, output) {\n$block\nreturn output;\n});\n";
+    return "Jemplate.applier(function(stash, context) {\nvar output='';\n$block\nreturn output;\n});\n";
     
 }
  

--- a/lib/Jemplate/Directive.pm
+++ b/lib/Jemplate/Directive.pm
@@ -19,24 +19,8 @@ sub template {
     my ($class, $block) = @_;
 
     return "function() { return ''; }" unless $block =~ /\S/;
-
-    return <<"...";
-function(context) {
-    if (! context) throw('Jemplate function called without context\\n');
-    var stash = context.stash;
-    var output = '';
-
-    try {
-$block
-    }
-    catch(e) {
-        var error = context.set_error(e, output);
-        throw(error);
-    }
-
-    return output;
-}
-...
+    return "Jemplate.applier(function(stash, output) { $block; return output; })";
+    
 }
  
 # Try to do 1 .. 10 expansions

--- a/lib/Jemplate/Directive.pm
+++ b/lib/Jemplate/Directive.pm
@@ -19,7 +19,7 @@ sub template {
     my ($class, $block) = @_;
 
     return "function() { return ''; }" unless $block =~ /\S/;
-    return "Jemplate.applier(function(stash, output) { $block; return output; })";
+    return "Jemplate.applier(function(stash, output) { $block return output; });\n";
     
 }
  

--- a/lib/Jemplate/Directive.pm
+++ b/lib/Jemplate/Directive.pm
@@ -19,7 +19,7 @@ sub template {
     my ($class, $block) = @_;
 
     return "function() { return ''; }" unless $block =~ /\S/;
-    return "Jemplate.applier(function(stash, output) {\n $block return output; });\n\n";
+    return "Jemplate.applier(function(stash, output) {\n$block\nreturn output;\n});\n";
     
 }
  


### PR DESCRIPTION
Trying to troubleshoot some of my generated templates, I was having a lot of trouble seeing through the boilerplate.

So I wrote a short extraction of the setup/try/catch, and added it to the main preamble.  The resulting template mappings now have reduced boilerplate.  I think there's more opportunity here, and may post additional updates if this is well received.

I had no trouble with the test suite, but only have Chrome available to browse it with.
