### PR TITLE
Export Jemplate in kernel.js

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -215,6 +215,55 @@ Jemplate development is being discussed at irc://irc.freenode.net/#jemplate
 
 If you want a committer bit, just ask ingy on the irc channel.
 
+# DEVELOPMENT TOOLS
+
+Here are the tools you will need to build the repo:
+
+* java
+* rhino (javascript interpreter written in java)
+    * On a Mac: `brew install rhino`
+* yapp (Parse::Yapp - Perl extension for generating and using LALR parsers.)
+    * `cpanm Parse::Yapp`
+* dzil (Dist::Zilla is a program to make it easier to write, package, manage, and release free software.)
+    * `cpanm Dist::Zilla`
+* Test::Base (Test::Base - A Data Driven Testing Framework)
+    * `cpanm Test::Base`
+* Zilla::Dist (Zilla::Dist - Dist::Zilla Mixed Up)
+    * `cpanm Zilla::Dist`
+
+# BUILDING
+
+Clone jemplate repo:
+
+    git clone git@github.com:buzzfeed/jemplate.git
+
+Clone Test::Base repo:
+
+    git clone https://github.com/ingydotnet/test-base-pm.git
+
+Change working directory to jemplate:
+
+    cd jemplate
+
+Install any missing author dependencies:
+
+    dzil authordeps --missing | cpanm
+
+Install any missing dependencies:
+
+    dzil listdeps --missing | cpanm
+
+At this point you can make changes in the repo.
+
+If you make any changes under `src` you should then run make to re-generate the javascript and perl code:
+
+    cd src
+    make
+
+Then commit your changes and use dzil at the top level to build the package:
+
+    dzil build
+
 # CREDIT
 
 This module is only possible because of Andy Wardley's mighty Template

--- a/src/js/kernel.js
+++ b/src/js/kernel.js
@@ -29,6 +29,10 @@ Jemplate.process = function() {
     return jemplate.process.apply(jemplate, arguments);
 }
 
+if (typeof(exports) == "object") {
+    exports.Jemplate = Jemplate;
+}
+
 ;(function(){
 
 if (! Jemplate.templateMap)


### PR DESCRIPTION
- export Jemplate in kernel.js
- update README with development tools and build details

This change was necessary to integrate Jemplate with spritesmith-cli, which can take an arbitrary templating engine for generating SCSS code. This specifically happens in the .spritesmith.js file which is documented here:

https://www.npmjs.org/package/spritesmith-cli

In order to include Jemplate into this config file, we need to require() it, as well as any templates we need to Jemplate to render. As it stands now, the Jemplate runtime does not export itself, even though the generated template files try to require it if exports is not defined:

https://github.com/ingydotnet/jemplate/blob/master/lib/Jemplate.pm#L401-L403

On a related note, I published an npm module for this modified Jemplate runtime (without Ajax or JSON support) so that it can be included as a dependency in our app:

https://www.npmjs.org/package/jemplate

If you have any feedback or questions, feel free to email me at joe.stanco@buzzfeed.com
