### PR TITLE
Add note/Hacking to explain how to set up for Test::Base

### DIFF
--- a/note/Hacking
+++ b/note/Hacking
@@ -1,0 +1,24 @@
+= HACKING
+
+To be able to build Jemplate you must first set up Dist::Zilla.
+
+% cpanm Dist::Zilla
+% dzil authordeps --missing | cpanm
+% dzil listdeps --missing | cpanm
+
+At this point the following command should complete successfully:
+
+% dzil build
+
+= TESTING
+
+The tests rely on Test::Base, as configured by the Dist::Zilla Plugin
+TestBaseIncluder. To run the tests you must have the git repository of
+Test::Base available in the parent directory!
+
+% git clone git@github.com:ingydotnet/test-base-pm.git ../test-base-pm
+
+At this point the following command should complete successfully:
+
+% dzil test --release
+


### PR DESCRIPTION
Hey Ingy,

I got Jemplate for my CPAN Pull Request Challenge for April, and I'm afraid I'm sending a pretty weak pull request over!

I tried getting Jemplate built and tested on my laptop and got caught up a bit on the Test::Base stuff, so I decided I could at least add a note for future devs. The requirement of having the git repo of Test::Base checked out in the parent directory threw me a bit. Is there a good reason for that requirement?
