### PR TITLE
Warn on duplicate template or block name.

### DIFF
--- a/lib/Jemplate.pm
+++ b/lib/Jemplate.pm
@@ -374,11 +374,16 @@ sub compile_template_content {
     my $parse_tree = $parser->parse(
         $template_content, {name => $template_name}
     ) or die $parser->error;
+    my $used_names = ref $self ? \$self->{USED_NAMES} : \ {};
+    warn "Duplicate template or block name $template_name\n"
+      if $$used_names->{$template_name}++;
     my $output =
         "Jemplate.templateMap['$template_name'] = " .
         $parse_tree->{BLOCK} .
         "\n";
     for my $function_name (sort keys %{$parse_tree->{DEFBLOCKS}}) {
+        warn "Duplicate template or block name $function_name\n"
+          if $$used_names->{$function_name}++;
         $output .=
             "Jemplate.templateMap['$function_name'] = " .
             $parse_tree->{DEFBLOCKS}{$function_name} .

--- a/t/9bug/gh8.t
+++ b/t/9bug/gh8.t
@@ -1,0 +1,41 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+
+use Jemplate;
+my $jemplate = Jemplate->new;
+
+my %warning_seen;
+local $SIG{__WARN__} = sub {
+    if ($_[0] =~ /Duplicate template or block name (b1|t2)/) {
+        ++$warning_seen{$1};
+    } else {
+        die "Unexpected warning: @_";
+    }
+};
+
+$jemplate->compile_template_content(
+    '[% BLOCK b1 %] first [% END %]',
+    't1',
+);
+
+$jemplate->compile_template_content(
+    '[% BLOCK b1 %] duplicate block [% END %]',
+    't2',
+);
+
+$jemplate->compile_template_content(
+    '[% BLOCK b2 %] duplicate template [% END %]',
+    't2',
+);
+
+is_deeply(
+    \%warning_seen,
+    { b1 => 1, t2 => 1 },
+    'duplicate warning seen'
+);
+
+done_testing();


### PR DESCRIPTION
Fixes #8.

Duplicate block name in the same file can't be reported from Jemplate,
we need to fix Template instead (in progress).